### PR TITLE
Add support for tail latency profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+# Runtime events tools
+
 A collection of observability tools around the runtime events tracing system
 introduced in OCaml 5.0.
 
-## olly
+## olly
 
 `olly` will report the GC tail latency profile of an OCaml executable.
 
@@ -70,6 +72,9 @@ menhir_sysver.trace
 ```
 
 This trace can be viewed in [perfetto trace viewer](https://ui.perfetto.dev/).
+
+![image](https://user-images.githubusercontent.com/410484/175475118-b08cbf06-a939-4edb-9336-20dfd464bb1b.png)
+
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ introduced in OCaml 5.0.
 
 ## olly
 
-`olly` will report the GC tail latency profile of an OCaml executable.
+`olly latency` will report the GC tail latency profile of an OCaml executable.
 
 ```bash
-$ olly ocamlopt.opt
+$ olly latency ocamlopt.opt
 GC latency profile:
 #[Mean (ms):    0.34,    Stddev (ms):   0.49]
 #[Min (ms):     0.01,    max (ms):      1.19]
@@ -35,7 +35,7 @@ Percentile       Latency (ms)
 ```
 
 ```bash
-$ olly 'menhir -v --table sysver.mly' # Use quotes for commands with arguments
+$ olly latency 'menhir -v --table sysver.mly' # Use quotes for commands with arguments
 <snip>
 GC latency profile:
 #[Mean (ms):    0.03,    Stddev (ms):   0.25]
@@ -62,10 +62,10 @@ Percentile       Latency (ms)
 100.0000         39.75
 ```
 
-`olly` can also record the runtime trace log in Chrome tracing format.
+`olly trace` will record the runtime trace log in Chrome tracing format.
 
 ```bash
-$ olly -t menhir_sysver.trace 'menhir -v --table sysver.mly'
+$ olly trace menhir_sysver.trace 'menhir -v --table sysver.mly'
 <snip>
 $ ls menhir_sysver.trace
 menhir_sysver.trace

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-A collection of tools around the runtime events tracing system introduced in OCaml 5.0.
+A collection of tools around the runtime events tracing system introduced in
+OCaml 5.0.
 
 ## ocaml-runtime-tracer
 
 ```
 Usage:
-$ ocaml-runtime-tracer <trace_filename> <executable> <args...> 
+$ olly <trace_filename> <executable> <args...> 
 ```
 
 `ocaml-runtime-tracer` will record the runtime tracelog to `<trace_filename>`
 of the given `<executable>` and `<args>`.
+
+## Dependencies
+
+The library depends on
+[`hdr_histogram_ocaml`](https://github.com/kayceesrk/hdr_histogram_ocaml).

--- a/README.md
+++ b/README.md
@@ -1,15 +1,47 @@
-A collection of tools around the runtime events tracing system introduced in
-OCaml 5.0.
+A collection of observability tools around the runtime events tracing system
+introduced in OCaml 5.0.
 
-## ocaml-runtime-tracer
+## olly
 
+`olly` will report the GC tail latency profile of an OCaml executable.
+
+```bash
+$ olly 'menhir -v --table sysver.mly'
+<snip>
+GC latency profile:
+#[Mean (ms):    0.03,    Stddev (ms):   0.25]
+#[Min (ms):     0.00,    max (ms):      39.75]
+
+Percentile       Latency (ms)
+25.0000          0.00
+50.0000          0.00
+60.0000          0.00
+70.0000          0.00
+75.0000          0.00
+80.0000          0.00
+85.0000          0.00
+90.0000          0.00
+95.0000          0.04
+96.0000          0.16
+97.0000          0.26
+98.0000          0.50
+99.0000          0.77
+99.9000          2.66
+99.9900          4.48
+99.9990          7.65
+99.9999          39.75
+100.0000         39.75
 ```
-Usage:
-$ olly <trace_filename> <executable> <args...> 
+
+`olly` can also record the runtime trace log in Chrome tracing format.
+
+```bash
+$ olly -t menhir_sysver.trace 'menhir -v --table sysver.mly'
+$ ls menhir_sysver.trace
+menhir_sysver.trace
 ```
 
-`ocaml-runtime-tracer` will record the runtime tracelog to `<trace_filename>`
-of the given `<executable>` and `<args>`.
+This trace can be viewed in [perfetto trace viewer](https://ui.perfetto.dev/).
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,34 @@ introduced in OCaml 5.0.
 `olly` will report the GC tail latency profile of an OCaml executable.
 
 ```bash
-$ olly 'menhir -v --table sysver.mly'
+$ olly ocamlopt.opt
+GC latency profile:
+#[Mean (ms):    0.34,    Stddev (ms):   0.49]
+#[Min (ms):     0.01,    max (ms):      1.19]
+
+Percentile       Latency (ms)
+25.0000          0.01
+50.0000          0.04
+60.0000          0.04
+70.0000          0.13
+75.0000          0.13
+80.0000          0.13
+85.0000          0.13
+90.0000          1.19
+95.0000          1.19
+96.0000          1.19
+97.0000          1.19
+98.0000          1.19
+99.0000          1.19
+99.9000          1.19
+99.9900          1.19
+99.9990          1.19
+99.9999          1.19
+100.0000         1.19
+```
+
+```bash
+$ olly 'menhir -v --table sysver.mly' # Use quotes for commands with arguments
 <snip>
 GC latency profile:
 #[Mean (ms):    0.03,    Stddev (ms):   0.25]
@@ -37,6 +64,7 @@ Percentile       Latency (ms)
 
 ```bash
 $ olly -t menhir_sysver.trace 'menhir -v --table sysver.mly'
+<snip>
 $ ls menhir_sysver.trace
 menhir_sysver.trace
 ```

--- a/bin/dune
+++ b/bin/dune
@@ -1,5 +1,5 @@
 (executable
- (public_name ocaml-runtime-tracer)
+ (public_name olly)
  (name runtime_tracer)
  (modules runtime_tracer)
- (libraries runtime_events unix))
+ (libraries runtime_events unix hdr_histogram cmdliner))

--- a/bin/dune
+++ b/bin/dune
@@ -1,5 +1,5 @@
 (executable
  (public_name olly)
- (name runtime_tracer)
- (modules runtime_tracer)
+ (name olly)
+ (modules olly)
  (libraries runtime_events unix hdr_histogram cmdliner))

--- a/bin/olly.ml
+++ b/bin/olly.ml
@@ -2,7 +2,6 @@ module H = Hdr_histogram
 module Ts = Runtime_events.Timestamp
 open Cmdliner
 
-
 let print_percentiles hist =
   let ms ns = ns /. 1000000. in
   Printf.eprintf "\n";

--- a/bin/runtime_tracer.ml
+++ b/bin/runtime_tracer.ml
@@ -21,20 +21,13 @@ let print_percentiles hist =
   Fun.flip Array.iter percentiles (fun p -> Printf.eprintf "%.4f \t %.2f\n" p
     (float_of_int (H.value_at_percentile hist p) |> ms))
 
-let olly trace_filename exec_args =
+let olly ~runtime_begin ~runtime_end ~cleanup ~init exec_args =
   let executable_filename, args =
     match String.split_on_char ' ' exec_args with
     | [] -> assert false
     | x::xs -> x,xs
   in
-  let trace_file = Option.map open_out trace_filename in
   let args = Array.of_list args in
-  let current_event = Hashtbl.create 13 in
-  let hist =
-    H.init ~lowest_discernible_value:10
-            ~highest_trackable_value:10_000_000_000
-            ~significant_figures:3
-  in
 
   (* Set the temp directory. We should make this configurable. *)
   let tmp_dir = Filename.get_temp_dir_name ()  ^ "/" in
@@ -48,49 +41,7 @@ let olly trace_filename exec_args =
                             Unix.stdin Unix.stdout Unix.stderr
   in
 
-  (* Helper for callbacks *)
-  let ts_to_us ts =
-    Int64.(div (Ts.to_int64 ts) (of_int 1000))
-  in
-
-  (* Callback functions for Runtime_events *)
-  let runtime_begin ring_id ts phase =
-    begin match trace_file with
-    | None -> ()
-    | Some f ->
-        Printf.fprintf f "{\"name\": \"%s\", \"cat\": \"PERF\", \"ph\":\"B\", \"ts\":%Ld, \"pid\": %d, \"tid\": %d},\n" (Runtime_events.runtime_phase_name phase) (ts_to_us ts) ring_id ring_id;
-        flush f
-    end;
-    begin match Hashtbl.find_opt current_event ring_id with
-    | None -> Hashtbl.add current_event ring_id (phase, Ts.to_int64 ts)
-    | _ -> ()
-    end
-  in
-
-  let runtime_end ring_id ts phase =
-    begin match trace_file with
-    | None -> ()
-    | Some f ->
-        Printf.fprintf f "{\"name\": \"%s\", \"cat\": \"PERF\", \"ph\":\"E\", \"ts\":%Ld, \"pid\": %d, \"tid\": %d},\n" (Runtime_events.runtime_phase_name phase) (ts_to_us ts) ring_id ring_id;
-        flush f
-    end;
-    begin match Hashtbl.find_opt current_event ring_id with
-    | Some (saved_phase, saved_ts) when (saved_phase = phase) ->
-        Hashtbl.remove current_event ring_id;
-        let latency =
-          Int64.to_int (Int64.sub (Ts.to_int64 ts) saved_ts)
-        in
-        assert (H.record_value hist latency)
-    | _ -> ()
-    end
-  in
-
-  (* emit prefix in the tracefile *)
-  begin match trace_file with
-  | None -> ()
-  | Some f -> Printf.fprintf f "["
-  end;
-
+  init ();
   (* Read from the child process *)
   Unix.sleep 1;
   let cursor = Runtime_events.create_cursor (Some (tmp_dir, child_pid)) in
@@ -107,38 +58,141 @@ let olly trace_filename exec_args =
   (* Do one more poll in case there are any remaining events we've missed *)
   Runtime_events.read_poll cursor callbacks None |> ignore;
 
-  print_percentiles hist;
-
   (* Now we're done, we need to remove the ring buffers ourselves because we
       told the child process not to remove them *)
   let ring_file =
     Filename.concat tmp_dir (string_of_int child_pid ^ ".events")
   in
   Unix.unlink ring_file;
-  ignore @@ Option.map close_out trace_file
+  cleanup ()
+
+let trace trace_filename exec_args =
+  let trace_file = open_out trace_filename in
+  let ts_to_us ts = Int64.(div (Ts.to_int64 ts) (of_int 1000)) in
+  let runtime_begin ring_id ts phase =
+      Printf.fprintf trace_file "{\"name\": \"%s\", \"cat\": \"PERF\", \"ph\":\"B\", \"ts\":%Ld, \"pid\": %d, \"tid\": %d},\n" (Runtime_events.runtime_phase_name phase) (ts_to_us ts) ring_id ring_id;
+      flush trace_file
+  in
+  let runtime_end ring_id ts phase =
+    Printf.fprintf trace_file "{\"name\": \"%s\", \"cat\": \"PERF\", \"ph\":\"E\", \"ts\":%Ld, \"pid\": %d, \"tid\": %d},\n" (Runtime_events.runtime_phase_name phase) (ts_to_us ts) ring_id ring_id;
+    flush trace_file
+  in
+  let init () =
+    (* emit prefix in the tracefile *)
+    Printf.fprintf trace_file "["
+  in
+  let cleanup () = close_out trace_file in
+  olly ~runtime_begin ~runtime_end ~init ~cleanup exec_args
+
+let latency exec_args =
+  let current_event = Hashtbl.create 13 in
+  let hist =
+    H.init ~lowest_discernible_value:10
+            ~highest_trackable_value:10_000_000_000
+            ~significant_figures:3
+  in
+  let runtime_begin ring_id ts phase =
+    match Hashtbl.find_opt current_event ring_id with
+    | None -> Hashtbl.add current_event ring_id (phase, Ts.to_int64 ts)
+    | _ -> ()
+  in
+  let runtime_end ring_id ts phase =
+    match Hashtbl.find_opt current_event ring_id with
+    | Some (saved_phase, saved_ts) when (saved_phase = phase) ->
+        Hashtbl.remove current_event ring_id;
+        let latency =
+          Int64.to_int (Int64.sub (Ts.to_int64 ts) saved_ts)
+        in
+        assert (H.record_value hist latency)
+    | _ -> ()
+  in
+  let init = Fun.id in
+  let cleanup () = print_percentiles hist in
+  olly ~runtime_begin ~runtime_end ~init ~cleanup exec_args
+
+let help man_format cmds topic =
+  match topic with
+  | None -> `Help (`Pager, None) (* help about the program. *)
+  | Some topic ->
+      let topics = "topics" :: cmds in
+      let conv, _ = Cmdliner.Arg.enum (List.rev_map (fun s -> (s, s)) topics) in
+      match conv topic with
+      | `Error e -> `Error (false, e)
+      | `Ok t when t = "topics" -> List.iter print_endline topics; `Ok ()
+      | `Ok t when List.mem t cmds -> `Help (man_format, Some t)
+      | `Ok _t ->
+          let page = (topic, 7, "", "", ""), [`S topic; `P "Say something";] in
+          `Ok (Cmdliner.Manpage.print man_format Format.std_formatter page)
 
 let () =
-  let trace_filename =
-    let doc = "Save the trace in $(docv) file in Chrome trace format." in
-    Arg.(value & opt (some string) None &
-         info ["t"; "trace-file"] ~docv:"TRACEFILE" ~doc)
+  (* Help sections common to all commands *)
+
+  let help_secs = [
+    `S Manpage.s_common_options;
+    `P "These options are common to all commands.";
+    `S "MORE HELP";
+    `P "Use $(mname) $(i,COMMAND) --help for help on a single command.";`Noblank;
+    `S Manpage.s_bugs; `P "Check bug reports at http://bugs.example.org.";]
   in
 
-  let exec_args =
+  (* Commands *)
+
+  let sdocs = Manpage.s_common_options in
+
+  let exec_args p =
     let doc = "Executable (and its arguments) to trace. If the executable takes
-               arguments, wrap quotes around the executable and its arguments.
-               For example, olly '<exec> <arg_1> <arg_2> ... <arg_n>'."
+              arguments, wrap quotes around the executable and its arguments.
+              For example, olly '<exec> <arg_1> <arg_2> ... <arg_n>'."
     in
-    Arg.(required & pos 0 (some string) None & info [] ~docv:"EXECUTABLE" ~doc)
+    Arg.(required & pos p (some string) None & info [] ~docv:"EXECUTABLE" ~doc)
   in
 
-  let olly_t =
-    Term.(const olly $ trace_filename $ exec_args)
+  let trace_cmd =
+    let trace_filename =
+      let doc = "Target trace file name." in
+      Arg.(required & pos 0 (some string) None & info [] ~docv:"TRACEFILE" ~doc)
+    in
+    let man = [
+      `S Manpage.s_description;
+      `P "Save the runtime trace in Chrome trace format.";
+      `Blocks help_secs; ]
+    in
+    let doc = "Save the runtime trace in Chrome trace format." in
+    let info = Cmd.info "trace" ~doc ~sdocs ~man in
+    Cmd.v info Term.(const trace $ trace_filename $ exec_args 1)
   in
-  let cmd =
+
+  let latency_cmd =
+    let man = [
+      `S Manpage.s_description;
+      `P "Report the GC latency profile.";
+      `Blocks help_secs; ]
+    in
+    let doc = "Report the GC latency profile." in
+    let info = Cmd.info "latency" ~doc ~sdocs ~man in
+    Cmd.v info Term.(const latency $ exec_args 0)
+  in
+
+  let help_cmd =
+    let topic =
+      let doc = "The topic to get help on. $(b,topics) lists the topics." in
+      Arg.(value & pos 0 (some string) None & info [] ~docv:"TOPIC" ~doc)
+    in
+    let doc = "Display help about olly and olly commands." in
+    let man =
+      [`S Manpage.s_description;
+      `P "Prints help about olly commands and other subjects…";
+      `Blocks help_secs; ]
+    in
+    let info = Cmd.info "help" ~doc ~man in
+    Cmd.v info
+      Term.(ret (const help $ Arg.man_format $ Term.choice_names $ topic))
+  in
+
+  let main_cmd =
     let doc = "An observability tool for OCaml programs" in
-    let info = Cmd.info "olly" ~doc in
-    Cmd.v info olly_t
+    let info = Cmd.info "olly" ~doc ~sdocs in
+    Cmd.group info [trace_cmd; latency_cmd; help_cmd]
   in
 
-  exit (Cmd.eval cmd)
+  exit (Cmd.eval main_cmd)

--- a/bin/runtime_tracer.ml
+++ b/bin/runtime_tracer.ml
@@ -1,28 +1,111 @@
+module H = Hdr_histogram
+module Ts = Runtime_events.Timestamp
+open Cmdliner
+
+
+let print_percentiles hist =
+  let ms ns = ns /. 1000000. in
+  Printf.eprintf "\n";
+  Printf.eprintf "#[Mean (ms):\t%.2f,\t Stddev (ms):\t%.2f]\n"
+    (H.mean hist |> ms) (H.stddev hist |> ms);
+  Printf.eprintf "#[Min (ms):\t%.2f,\t max (ms):\t%.2f]\n"
+    (float_of_int (H.min hist) |> ms) (float_of_int (H.max hist) |> ms);
+
+  Printf.eprintf "\n";
+  let percentiles = [| 50.0; 75.0; 90.0; 99.0; 99.9; 99.99; 99.999; 100.0 |] in
+  Printf.eprintf "percentile \t latency (ms)\n";
+  Fun.flip Array.iter percentiles (fun p -> Printf.eprintf "%.4f \t %.2f\n" p
+    (float_of_int (H.value_at_percentile hist p) |> ms))
+
+let olly trace_filename executable_filename args =
+
 let () =
+  let trace_filename =
+    let doc = "Save the trace in $(docv) file in Chrome trace format." in
+    Arg.(value & opt (some string) None &
+         info ["t"; "trace-file"] ~docv:"TRACEFILE" ~doc)
+  in
+
+  let executable_filename =
+    let doc = "Executable to trace." in
+    Arg.(required & pos 0 (some string) None & info [] ~docv:"EXECUTABLE" ~doc)
+  in
+
+  let args =
+    let doc = "Arguments." in
+    Arg.(value & pos_right 0 string [] & info [] ~docv:"ARGUMENTS")
+  in
+
+  let olly_t = Term.(const chorus $ count $ msg)
+  let cmd =
+    let doc = "trace an OCaml executable" in
+    let info = Cmd.info "chorus" ~version:"%‌%VERSION%%" ~doc ~man in
+    Cmd.v info chorus_t
+
+
+
   if Array.length Sys.argv < 3 then
     Printf.eprintf "%s <trace_filename> <executable> <args> ...\n" Sys.argv.(0)
   else begin
+
     (* Parse arguments and set up environment *)
     let trace_filename = Sys.argv.(1) in
     let trace_file = open_out trace_filename in
     Printf.fprintf trace_file "[";
     let executable_filename = Sys.argv.(2) in
-    let args = if Array.length Sys.argv > 3 then Array.sub Sys.argv 2 (Array.length Sys.argv - 2) else [||] in
+    let args =
+      if Array.length Sys.argv > 3 then
+        Array.sub Sys.argv 2 (Array.length Sys.argv - 2)
+      else [||]
+    in
+    let current_event = Hashtbl.create 13 in
+    let hist =
+      H.init ~lowest_discernible_value:10
+             ~highest_trackable_value:10_000_000_000
+             ~significant_figures:3
+    in
+
     (* Set the temp directory. We should make this configurable. *)
     let tmp_dir = Filename.get_temp_dir_name ()  ^ "/" in
-    let env = [Unix.environment (); [| "OCAML_RUNTIME_EVENTS_START=1"; "OCAML_RUNTIME_EVENTS_DIR=" ^ tmp_dir; "OCAML_RUNTIME_EVENTS_PRESERVE=1" |]] |> Array.concat in
-    let child_pid = Unix.create_process_env executable_filename args env Unix.stdin Unix.stdout Unix.stderr in
+    let env = Array.append [| "OCAML_RUNTIME_EVENTS_START=1";
+                              "OCAML_RUNTIME_EVENTS_DIR=" ^ tmp_dir;
+                              "OCAML_RUNTIME_EVENTS_PRESERVE=1" |]
+                           (Unix.environment ())
+    in
+    let child_pid =
+      Unix.create_process_env executable_filename args env
+                              Unix.stdin Unix.stdout Unix.stderr
+    in
+
     (* Helper for callbacks *)
-    let ts_to_ms ts = Int64.(div (Runtime_events.Timestamp.to_int64 ts) (of_int 1000)) in
+    let ts_to_us ts =
+      Int64.(div (Ts.to_int64 ts) (of_int 1000))
+    in
+
     (* Callback functions for Runtime_events *)
     let runtime_begin ring_id ts phase =
       Printf.fprintf trace_file "{\"name\": \"%s\", \"cat\": \"PERF\", \"ph\":\"B\", \"ts\":%Ld, \"pid\": %d, \"tid\": %d},\n"
-        (Runtime_events.runtime_phase_name phase) (ts_to_ms ts) ring_id ring_id;
-      flush trace_file in
+        (Runtime_events.runtime_phase_name phase) (ts_to_us ts) ring_id ring_id;
+      flush trace_file;
+      match Hashtbl.find_opt current_event ring_id with
+      | None -> Hashtbl.add current_event ring_id (phase, Ts.to_int64 ts)
+      | _ -> ()
+    in
+
     let runtime_end ring_id ts phase =
       Printf.fprintf trace_file "{\"name\": \"%s\", \"cat\": \"PERF\", \"ph\":\"E\", \"ts\":%Ld, \"pid\": %d, \"tid\": %d},\n"
-        (Runtime_events.runtime_phase_name phase) (ts_to_ms ts) ring_id ring_id;
-      flush trace_file in
+        (Runtime_events.runtime_phase_name phase) (ts_to_us ts) ring_id ring_id;
+      flush trace_file;
+      match Hashtbl.find_opt current_event ring_id with
+      | Some (saved_phase, saved_ts) when (saved_phase = phase) ->
+          Hashtbl.remove current_event ring_id;
+          let latency =
+            Int64.to_int (Int64.sub (Ts.to_int64 ts) saved_ts)
+          in
+          assert (H.record_value hist latency)
+      | _ -> ()
+    in
+
     (* Read from the child process *)
     Unix.sleep 1;
     let cursor = Runtime_events.create_cursor (Some (tmp_dir, child_pid)) in
@@ -35,12 +118,16 @@ let () =
       Runtime_events.read_poll cursor callbacks None |> ignore;
       Unix.sleepf 0.1 (* Poll at 10Hz *)
     end done;
+
     (* Do one more poll in case there are any remaining events we've missed *)
     Runtime_events.read_poll cursor callbacks None |> ignore;
+
+    print_percentiles hist;
+
     (* Now we're done, we need to remove the ring buffers ourselves because we
-      told the child process not to remove them *)
+       told the child process not to remove them *)
     let ring_file =
-        Filename.concat tmp_dir (string_of_int child_pid ^ ".events") in
+      Filename.concat tmp_dir (string_of_int child_pid ^ ".events")
+    in
     Unix.unlink ring_file
   end
-

--- a/bin/runtime_tracer.ml
+++ b/bin/runtime_tracer.ml
@@ -85,6 +85,12 @@ let olly trace_filename exec_args =
     end
   in
 
+  (* emit prefix in the tracefile *)
+  begin match trace_file with
+  | None -> ()
+  | Some f -> Printf.fprintf f "["
+  end;
+
   (* Read from the child process *)
   Unix.sleep 1;
   let cursor = Runtime_events.create_cursor (Some (tmp_dir, child_pid)) in

--- a/bin/runtime_tracer.ml
+++ b/bin/runtime_tracer.ml
@@ -17,7 +17,95 @@ let print_percentiles hist =
   Fun.flip Array.iter percentiles (fun p -> Printf.eprintf "%.4f \t %.2f\n" p
     (float_of_int (H.value_at_percentile hist p) |> ms))
 
-let olly trace_filename executable_filename args =
+let olly trace_filename exec_args =
+  let executable_filename, args =
+    match String.split_on_char ' ' exec_args with
+    | [] -> assert false
+    | x::xs -> x,xs
+  in
+  let trace_file = Option.map open_out trace_filename in
+  let args = Array.of_list args in
+  let current_event = Hashtbl.create 13 in
+  let hist =
+    H.init ~lowest_discernible_value:10
+            ~highest_trackable_value:10_000_000_000
+            ~significant_figures:3
+  in
+
+  (* Set the temp directory. We should make this configurable. *)
+  let tmp_dir = Filename.get_temp_dir_name ()  ^ "/" in
+  let env = Array.append [| "OCAML_RUNTIME_EVENTS_START=1";
+                            "OCAML_RUNTIME_EVENTS_DIR=" ^ tmp_dir;
+                            "OCAML_RUNTIME_EVENTS_PRESERVE=1" |]
+                          (Unix.environment ())
+  in
+  let child_pid =
+    Unix.create_process_env executable_filename args env
+                            Unix.stdin Unix.stdout Unix.stderr
+  in
+
+  (* Helper for callbacks *)
+  let ts_to_us ts =
+    Int64.(div (Ts.to_int64 ts) (of_int 1000))
+  in
+
+  (* Callback functions for Runtime_events *)
+  let runtime_begin ring_id ts phase =
+    begin match trace_file with
+    | None -> ()
+    | Some f ->
+        Printf.fprintf f "{\"name\": \"%s\", \"cat\": \"PERF\", \"ph\":\"B\", \"ts\":%Ld, \"pid\": %d, \"tid\": %d},\n" (Runtime_events.runtime_phase_name phase) (ts_to_us ts) ring_id ring_id;
+        flush f
+    end;
+    begin match Hashtbl.find_opt current_event ring_id with
+    | None -> Hashtbl.add current_event ring_id (phase, Ts.to_int64 ts)
+    | _ -> ()
+    end
+  in
+
+  let runtime_end ring_id ts phase =
+    begin match trace_file with
+    | None -> ()
+    | Some f ->
+        Printf.fprintf f "{\"name\": \"%s\", \"cat\": \"PERF\", \"ph\":\"E\", \"ts\":%Ld, \"pid\": %d, \"tid\": %d},\n" (Runtime_events.runtime_phase_name phase) (ts_to_us ts) ring_id ring_id;
+        flush f
+    end;
+    begin match Hashtbl.find_opt current_event ring_id with
+    | Some (saved_phase, saved_ts) when (saved_phase = phase) ->
+        Hashtbl.remove current_event ring_id;
+        let latency =
+          Int64.to_int (Int64.sub (Ts.to_int64 ts) saved_ts)
+        in
+        assert (H.record_value hist latency)
+    | _ -> ()
+    end
+  in
+
+  (* Read from the child process *)
+  Unix.sleep 1;
+  let cursor = Runtime_events.create_cursor (Some (tmp_dir, child_pid)) in
+  let callbacks = Runtime_events.Callbacks.create ~runtime_begin ~runtime_end () in
+  let child_alive () = match Unix.waitpid [ Unix.WNOHANG ] child_pid with
+    | (0, _) -> true
+    | (p, _) when p = child_pid -> false
+    | (_, _) -> assert(false) in
+  while child_alive () do begin
+    Runtime_events.read_poll cursor callbacks None |> ignore;
+    Unix.sleepf 0.1 (* Poll at 10Hz *)
+  end done;
+
+  (* Do one more poll in case there are any remaining events we've missed *)
+  Runtime_events.read_poll cursor callbacks None |> ignore;
+
+  print_percentiles hist;
+
+  (* Now we're done, we need to remove the ring buffers ourselves because we
+      told the child process not to remove them *)
+  let ring_file =
+    Filename.concat tmp_dir (string_of_int child_pid ^ ".events")
+  in
+  Unix.unlink ring_file;
+  ignore @@ Option.map close_out trace_file
 
 let () =
   let trace_filename =
@@ -26,108 +114,21 @@ let () =
          info ["t"; "trace-file"] ~docv:"TRACEFILE" ~doc)
   in
 
-  let executable_filename =
-    let doc = "Executable to trace." in
+  let exec_args =
+    let doc = "Executable (and its arguments) to trace. If the executable takes
+               arguments, wrap quotes around the executable and its arguments.
+               For example, olly '<exec> <arg_1> <arg_2> ... <arg_n>'."
+    in
     Arg.(required & pos 0 (some string) None & info [] ~docv:"EXECUTABLE" ~doc)
   in
 
-  let args =
-    let doc = "Arguments." in
-    Arg.(value & pos_right 0 string [] & info [] ~docv:"ARGUMENTS")
+  let olly_t =
+    Term.(const olly $ trace_filename $ exec_args)
   in
-
-  let olly_t = Term.(const chorus $ count $ msg)
   let cmd =
     let doc = "trace an OCaml executable" in
-    let info = Cmd.info "chorus" ~version:"%‌%VERSION%%" ~doc ~man in
-    Cmd.v info chorus_t
+    let info = Cmd.info "olly" ~doc in
+    Cmd.v info olly_t
+  in
 
-
-
-  if Array.length Sys.argv < 3 then
-    Printf.eprintf "%s <trace_filename> <executable> <args> ...\n" Sys.argv.(0)
-  else begin
-
-    (* Parse arguments and set up environment *)
-    let trace_filename = Sys.argv.(1) in
-    let trace_file = open_out trace_filename in
-    Printf.fprintf trace_file "[";
-    let executable_filename = Sys.argv.(2) in
-    let args =
-      if Array.length Sys.argv > 3 then
-        Array.sub Sys.argv 2 (Array.length Sys.argv - 2)
-      else [||]
-    in
-    let current_event = Hashtbl.create 13 in
-    let hist =
-      H.init ~lowest_discernible_value:10
-             ~highest_trackable_value:10_000_000_000
-             ~significant_figures:3
-    in
-
-    (* Set the temp directory. We should make this configurable. *)
-    let tmp_dir = Filename.get_temp_dir_name ()  ^ "/" in
-    let env = Array.append [| "OCAML_RUNTIME_EVENTS_START=1";
-                              "OCAML_RUNTIME_EVENTS_DIR=" ^ tmp_dir;
-                              "OCAML_RUNTIME_EVENTS_PRESERVE=1" |]
-                           (Unix.environment ())
-    in
-    let child_pid =
-      Unix.create_process_env executable_filename args env
-                              Unix.stdin Unix.stdout Unix.stderr
-    in
-
-    (* Helper for callbacks *)
-    let ts_to_us ts =
-      Int64.(div (Ts.to_int64 ts) (of_int 1000))
-    in
-
-    (* Callback functions for Runtime_events *)
-    let runtime_begin ring_id ts phase =
-      Printf.fprintf trace_file "{\"name\": \"%s\", \"cat\": \"PERF\", \"ph\":\"B\", \"ts\":%Ld, \"pid\": %d, \"tid\": %d},\n"
-        (Runtime_events.runtime_phase_name phase) (ts_to_us ts) ring_id ring_id;
-      flush trace_file;
-      match Hashtbl.find_opt current_event ring_id with
-      | None -> Hashtbl.add current_event ring_id (phase, Ts.to_int64 ts)
-      | _ -> ()
-    in
-
-    let runtime_end ring_id ts phase =
-      Printf.fprintf trace_file "{\"name\": \"%s\", \"cat\": \"PERF\", \"ph\":\"E\", \"ts\":%Ld, \"pid\": %d, \"tid\": %d},\n"
-        (Runtime_events.runtime_phase_name phase) (ts_to_us ts) ring_id ring_id;
-      flush trace_file;
-      match Hashtbl.find_opt current_event ring_id with
-      | Some (saved_phase, saved_ts) when (saved_phase = phase) ->
-          Hashtbl.remove current_event ring_id;
-          let latency =
-            Int64.to_int (Int64.sub (Ts.to_int64 ts) saved_ts)
-          in
-          assert (H.record_value hist latency)
-      | _ -> ()
-    in
-
-    (* Read from the child process *)
-    Unix.sleep 1;
-    let cursor = Runtime_events.create_cursor (Some (tmp_dir, child_pid)) in
-    let callbacks = Runtime_events.Callbacks.create ~runtime_begin ~runtime_end () in
-    let child_alive () = match Unix.waitpid [ Unix.WNOHANG ] child_pid with
-      | (0, _) -> true
-      | (p, _) when p = child_pid -> false
-      | (_, _) -> assert(false) in
-    while child_alive () do begin
-      Runtime_events.read_poll cursor callbacks None |> ignore;
-      Unix.sleepf 0.1 (* Poll at 10Hz *)
-    end done;
-
-    (* Do one more poll in case there are any remaining events we've missed *)
-    Runtime_events.read_poll cursor callbacks None |> ignore;
-
-    print_percentiles hist;
-
-    (* Now we're done, we need to remove the ring buffers ourselves because we
-       told the child process not to remove them *)
-    let ring_file =
-      Filename.concat tmp_dir (string_of_int child_pid ^ ".events")
-    in
-    Unix.unlink ring_file
-  end
+  exit (Cmd.eval cmd)

--- a/bin/runtime_tracer.ml
+++ b/bin/runtime_tracer.ml
@@ -6,14 +6,18 @@ open Cmdliner
 let print_percentiles hist =
   let ms ns = ns /. 1000000. in
   Printf.eprintf "\n";
+  Printf.eprintf "GC latency profile:\n";
   Printf.eprintf "#[Mean (ms):\t%.2f,\t Stddev (ms):\t%.2f]\n"
     (H.mean hist |> ms) (H.stddev hist |> ms);
   Printf.eprintf "#[Min (ms):\t%.2f,\t max (ms):\t%.2f]\n"
     (float_of_int (H.min hist) |> ms) (float_of_int (H.max hist) |> ms);
 
   Printf.eprintf "\n";
-  let percentiles = [| 50.0; 75.0; 90.0; 99.0; 99.9; 99.99; 99.999; 100.0 |] in
-  Printf.eprintf "percentile \t latency (ms)\n";
+  let percentiles = [| 25.0; 50.0; 60.0; 70.0; 75.0; 80.0; 85.0; 90.0; 95.0;
+                       96.0; 97.0; 98.0; 99.0; 99.9; 99.99; 99.999; 99.9999;
+                       100.0 |]
+  in
+  Printf.eprintf "Percentile \t Latency (ms)\n";
   Fun.flip Array.iter percentiles (fun p -> Printf.eprintf "%.4f \t %.2f\n" p
     (float_of_int (H.value_at_percentile hist p) |> ms))
 
@@ -126,7 +130,7 @@ let () =
     Term.(const olly $ trace_filename $ exec_args)
   in
   let cmd =
-    let doc = "trace an OCaml executable" in
+    let doc = "An observability tool for OCaml programs" in
     let info = Cmd.info "olly" ~doc in
     Cmd.v info olly_t
   in

--- a/dune-project
+++ b/dune-project
@@ -15,4 +15,4 @@
  (name runtime_events_tools)
  (synopsis "Tools for the runtime events tracing system in OCaml")
  (description "Various tools for the runtime events tracing system in OCaml")
- (depends (ocaml (>= "5.0.0~")) ocamlfind))
+ (depends (ocaml (>= "5.0.0~")) ocamlfind hdr_histogram cmdliner))

--- a/runtime_events_tools.opam
+++ b/runtime_events_tools.opam
@@ -11,6 +11,8 @@ depends: [
   "dune" {>= "3.2"}
   "ocaml" {>= "5.0.0~"}
   "ocamlfind"
+  "hdr_histogram"
+  "cmdliner"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Rename the tool as `olly`. Add subcommands (using `cmdliner`) for tracing and latency profiling (using hdr histogram).
