### PR TITLE
Add Fuchsia Trace Format output to olly

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -2,4 +2,4 @@
  (public_name olly)
  (name olly)
  (modules olly)
- (libraries runtime_events unix hdr_histogram cmdliner))
+ (libraries runtime_events unix hdr_histogram cmdliner tracing))

--- a/dune-project
+++ b/dune-project
@@ -15,4 +15,4 @@
  (name runtime_events_tools)
  (synopsis "Tools for the runtime events tracing system in OCaml")
  (description "Various tools for the runtime events tracing system in OCaml")
- (depends (ocaml (>= "5.0.0~")) ocamlfind hdr_histogram cmdliner))
+ (depends (ocaml (>= "5.0.0~")) ocamlfind hdr_histogram cmdliner tracing))

--- a/runtime_events_tools.opam
+++ b/runtime_events_tools.opam
@@ -13,6 +13,7 @@ depends: [
   "ocamlfind"
   "hdr_histogram"
   "cmdliner"
+  "tracing"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
FTF is a binary format viewable in Perfetto. FTF is supported by the opam tracing package. This commit is a simple change to add FTF output to olly, following the [trace] code that already outputs Chrome Tracing Format traces.